### PR TITLE
Remove id and nullable options from definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,10 @@ fastify.register(require('fastify-swagger'), {
     ],
     definitions: {
       User: {
-        $id: 'User',
         type: 'object',
         required: ['id', 'email'],
         properties: {
           id: { type: 'string', format: 'uuid' },
-          firstName: { type: 'string', nullable: true },
-          lastName: { type: 'string', nullable: true },
           email: {type: 'string', format: 'email' }
         }
       }


### PR DESCRIPTION
Remove id and nullable options from `definitions.User` to avoid TS schema error.